### PR TITLE
Add Obscura seed nodes for devnet and mainnet

### DIFF
--- a/networks/devnet.txt
+++ b/networks/devnet.txt
@@ -1,4 +1,4 @@
+/dns4/mina-devnet-seed.obscura.network/tcp/5001/p2p/12D3KooWJmvacFHYnF5PLEQrpWQkssPN52gWi8i6oMaEeCdNuocU
 /dns4/seed-1.devnet.gcp.o1test.net/tcp/10003/p2p/12D3KooWAdgYL6hv18M3iDBdaK1dRygPivSfAfBNDzie6YqydVbs
 /dns4/seed-2.devnet.gcp.o1test.net/tcp/10003/p2p/12D3KooWLjs54xHzVmMmGYb7W5RVibqbwD1co7M2ZMfPgPm7iAag
 /dns4/seed-3.devnet.gcp.o1test.net/tcp/10003/p2p/12D3KooWEiGVAFC7curXWXiGZyMWnZK9h8BKr88U8D5PKV3dXciv
-/dns4/mina-devnet-seed.obscura.network/tcp/5001/p2p/12D3KooWJmvacFHYnF5PLEQrpWQkssPN52gWi8i6oMaEeCdNuocU

--- a/networks/devnet.txt
+++ b/networks/devnet.txt
@@ -1,3 +1,4 @@
 /dns4/seed-1.devnet.gcp.o1test.net/tcp/10003/p2p/12D3KooWAdgYL6hv18M3iDBdaK1dRygPivSfAfBNDzie6YqydVbs
 /dns4/seed-2.devnet.gcp.o1test.net/tcp/10003/p2p/12D3KooWLjs54xHzVmMmGYb7W5RVibqbwD1co7M2ZMfPgPm7iAag
 /dns4/seed-3.devnet.gcp.o1test.net/tcp/10003/p2p/12D3KooWEiGVAFC7curXWXiGZyMWnZK9h8BKr88U8D5PKV3dXciv
+/ip4/51.178.128.35/tcp/5001/p2p/12D3KooWJmvacFHYnF5PLEQrpWQkssPN52gWi8i6oMaEeCdNuocU

--- a/networks/devnet.txt
+++ b/networks/devnet.txt
@@ -1,4 +1,4 @@
 /dns4/seed-1.devnet.gcp.o1test.net/tcp/10003/p2p/12D3KooWAdgYL6hv18M3iDBdaK1dRygPivSfAfBNDzie6YqydVbs
 /dns4/seed-2.devnet.gcp.o1test.net/tcp/10003/p2p/12D3KooWLjs54xHzVmMmGYb7W5RVibqbwD1co7M2ZMfPgPm7iAag
 /dns4/seed-3.devnet.gcp.o1test.net/tcp/10003/p2p/12D3KooWEiGVAFC7curXWXiGZyMWnZK9h8BKr88U8D5PKV3dXciv
-/ip4/51.178.128.35/tcp/5001/p2p/12D3KooWJmvacFHYnF5PLEQrpWQkssPN52gWi8i6oMaEeCdNuocU
+/dns4/mina-devnet-seed.obscura.network/tcp/5001/p2p/12D3KooWJmvacFHYnF5PLEQrpWQkssPN52gWi8i6oMaEeCdNuocU

--- a/networks/mainnet.txt
+++ b/networks/mainnet.txt
@@ -7,4 +7,4 @@
 /dns4/seed-2.mainnet.o1test.net/tcp/10001/p2p/12D3KooWK4NfthViCTyLgVQa1WvqDC1NccVxGruCXCZUt3GqvFvn
 /dns4/seed-3.mainnet.o1test.net/tcp/10002/p2p/12D3KooWNofeYVAJXA3WGg2qCDhs3GEe71kTmKpFQXRbZmCz1Vr7
 /dns4/seed.minaexplorer.com/tcp/8302/p2p/12D3KooWR7coZtrMHvsgsfiWq2GESYypac3i29LFGp6EpbtjxBiJ
-/ip4/51.178.128.35/tcp/5002/p2p/12D3KooWLMHuJrir6q42qUiihZmqJshzWZ6baYNP6zs3UtJt67BF
+/dns4/mina-mainnet-seed.obscura.network/tcp/5002/p2p/12D3KooWLMHuJrir6q42qUiihZmqJshzWZ6baYNP6zs3UtJt67BF

--- a/networks/mainnet.txt
+++ b/networks/mainnet.txt
@@ -7,3 +7,4 @@
 /dns4/seed-2.mainnet.o1test.net/tcp/10001/p2p/12D3KooWK4NfthViCTyLgVQa1WvqDC1NccVxGruCXCZUt3GqvFvn
 /dns4/seed-3.mainnet.o1test.net/tcp/10002/p2p/12D3KooWNofeYVAJXA3WGg2qCDhs3GEe71kTmKpFQXRbZmCz1Vr7
 /dns4/seed.minaexplorer.com/tcp/8302/p2p/12D3KooWR7coZtrMHvsgsfiWq2GESYypac3i29LFGp6EpbtjxBiJ
+/ip4/51.178.128.35/tcp/5002/p2p/12D3KooWLMHuJrir6q42qUiihZmqJshzWZ6baYNP6zs3UtJt67BF

--- a/networks/mainnet.txt
+++ b/networks/mainnet.txt
@@ -1,3 +1,4 @@
+/dns4/mina-mainnet-seed.obscura.network/tcp/5002/p2p/12D3KooWLMHuJrir6q42qUiihZmqJshzWZ6baYNP6zs3UtJt67BF
 /dns4/mina-mainnet-seed.staketab.com/tcp/10003/p2p/12D3KooWSDTiXcdBVpN12ZqXJ49qCFp8zB1NnovuhZu6A28GLF1J
 /dns4/mina-seed-1.zkvalidator.com/tcp/8302/p2p/12D3KooWSR7LMBSfEk3LQUudmsX27yuRHe9NUxwLumurGF5P1MNS
 /dns4/mina-seed.bitcat365.com/tcp/10001/p2p/12D3KooWQzozNTDKL7MqUh6Nh11GMA4pQhRCAsNTRWxCAzAi4VbE
@@ -7,4 +8,3 @@
 /dns4/seed-2.mainnet.o1test.net/tcp/10001/p2p/12D3KooWK4NfthViCTyLgVQa1WvqDC1NccVxGruCXCZUt3GqvFvn
 /dns4/seed-3.mainnet.o1test.net/tcp/10002/p2p/12D3KooWNofeYVAJXA3WGg2qCDhs3GEe71kTmKpFQXRbZmCz1Vr7
 /dns4/seed.minaexplorer.com/tcp/8302/p2p/12D3KooWR7coZtrMHvsgsfiWq2GESYypac3i29LFGp6EpbtjxBiJ
-/dns4/mina-mainnet-seed.obscura.network/tcp/5002/p2p/12D3KooWLMHuJrir6q42qUiihZmqJshzWZ6baYNP6zs3UtJt67BF


### PR DESCRIPTION
[Obscura](https://obscura.network/) is running seed-nodes with static IP-addresses for devnet and mainnet.